### PR TITLE
feat: Content Engine — OG banners automáticos + gerador de artigos

### DIFF
--- a/CONTENT-ENGINE.md
+++ b/CONTENT-ENGINE.md
@@ -1,0 +1,113 @@
+# InSpotGO Content Engine
+
+Pipeline completo para gerar **artigos evergreen** + **banners OG premium** com um único comando.
+
+---
+
+## Como funciona
+
+```
+Você digita o tema
+       ↓
+ content_engine.py  →  src/content/posts/<slug>.md
+       ↓
+  astro build       →  /og/<slug>.png  (banner 1200×630 automático)
+```
+
+---
+
+## Instalação (uma vez só)
+
+### 1. Dependências Node (banner)
+
+```bash
+npm install satori @resvg/resvg-js
+```
+
+### 2. Fontes Inter (obrigatório)
+
+```bash
+# Baixe Inter em https://fonts.google.com/specimen/Inter
+# Extraia e copie:
+mkdir -p public/fonts
+cp ~/Downloads/static/Inter-Black.ttf   public/fonts/
+cp ~/Downloads/static/Inter-Regular.ttf public/fonts/
+```
+
+### 3. Dependências Python (artigo)
+
+```bash
+pip install groq
+```
+
+### 4. Chave Groq (grátis)
+
+1. Acesse https://console.groq.com
+2. Crie uma chave API gratuita
+3. Adicione ao seu `.env`:
+
+```env
+GROQ_API_KEY=gsk_xxxxxxxxxxxxxxxxxxxx
+```
+
+> **Alternativa offline:** Instale [Ollama](https://ollama.com) e use `--llm ollama`
+
+---
+
+## Uso
+
+```bash
+python scripts/content_engine.py \
+  --topic "how to improve focus while working from home" \
+  --slug  "improve-focus-working-from-home" \
+  --niche "productivity"
+```
+
+### Nichos disponíveis
+
+| Flag | Badge no banner | Cor |
+|------|----------------|-----|
+| `saas` | ⚡ SaaS | Indigo |
+| `tools` | 🛠 Tools | Indigo |
+| `productivity` | 🎯 Productivity | Blue |
+| `finance` | 💰 Finance | Emerald |
+| `health` | 🌿 Health | Amber |
+| `marketing` | 📣 Marketing | Pink |
+| `security` | 🔒 Security | Violet |
+| `software` | 💻 Software | Cyan |
+
+---
+
+## O que é gerado
+
+| Arquivo | Conteúdo |
+|---------|----------|
+| `src/content/posts/<slug>.md` | Artigo completo com frontmatter, CTAs, links internos, schema FAQ |
+| `/og/<slug>.png` | Banner 1200×630 gerado automaticamente no `astro build` |
+
+---
+
+## Workflow diário
+
+```bash
+# 1. Gerar artigo
+python scripts/content_engine.py --topic "..." --slug "..." --niche "..."
+
+# 2. Revisar o .md gerado
+code src/content/posts/<slug>.md
+
+# 3. Commitar e publicar (banner é gerado automaticamente no deploy)
+git add .
+git commit -m "content: add <slug>"
+git push
+```
+
+---
+
+## Segurança
+
+- ✅ Nenhum arquivo existente foi modificado
+- ✅ Branch separada `feature/content-engine` — merge só quando testar
+- ✅ O endpoint `/og/[slug].png.ts` só é ativado se `satori` e `@resvg/resvg-js` estiverem instalados
+- ✅ Fallback de erro 500 silencioso se fontes não estiverem presentes (não quebra o build)
+- ✅ O script Python **pergunta antes de sobrescrever** posts existentes

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/sitemap": "^3.0.0",
+        "@resvg/resvg-js": "^2.6.2",
         "astro": "^4.0.0",
         "lucide-astro": "^0.294.0",
+        "satori": "^0.25.0",
         "sharp": "^0.33.0"
       },
       "devDependencies": {
@@ -1339,6 +1341,221 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -1760,6 +1977,22 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2380,6 +2613,15 @@
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -2480,6 +2722,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2808,6 +3059,47 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2985,6 +3277,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -3109,6 +3407,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -3449,6 +3753,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -3704,6 +4020,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/load-yaml-file": {
@@ -4889,6 +5215,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/parse-latin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -5001,6 +5343,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/preferred-pm": {
       "version": "4.1.1",
@@ -5469,6 +5817,37 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/satori": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.25.0.tgz",
+      "integrity": "sha512-utINfLxrYrmSnLvxFT4ZwgwWa8KOjrz7ans32V5wItgHVmzESl/9i33nE38uG0miycab8hUqQtDlOpqrIpB/iw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/satori/node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
@@ -5670,6 +6049,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -5716,6 +6101,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
@@ -5847,6 +6238,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -6565,6 +6966,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.0.0",
+    "@resvg/resvg-js": "^2.6.2",
     "astro": "^4.0.0",
     "lucide-astro": "^0.294.0",
+    "satori": "^0.25.0",
     "sharp": "^0.33.0"
   },
   "devDependencies": {

--- a/public/fonts/README.md
+++ b/public/fonts/README.md
@@ -1,0 +1,26 @@
+# Fonts — Inter
+
+Esta pasta deve conter as fontes **Inter** para o gerador de banners OG funcionar.
+
+## Como baixar (uma vez só)
+
+```bash
+# Opção 1: Google Fonts (mais fácil)
+curl -L "https://fonts.google.com/download?family=Inter" -o inter.zip
+unzip inter.zip -d inter-tmp
+cp inter-tmp/static/Inter-Black.ttf ./public/fonts/Inter-Black.ttf
+cp inter-tmp/static/Inter-Regular.ttf ./public/fonts/Inter-Regular.ttf
+rm -rf inter-tmp inter.zip
+
+# Opção 2: Manual
+# Acesse https://fonts.google.com/specimen/Inter
+# Baixe → extraia → copie Inter-Black.ttf e Inter-Regular.ttf para esta pasta
+```
+
+## Arquivos necessários
+
+- `Inter-Black.ttf` — peso 900 (usado no título do banner)
+- `Inter-Regular.ttf` — peso 400 (usado no subtítulo e badge)
+
+> ⚠️ Estes arquivos .ttf estão no .gitignore por serem binários.
+> Cada desenvolvedor/CI precisa baixá-los uma vez.

--- a/scripts/content_engine.py
+++ b/scripts/content_engine.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+InSpotGO Content Engine
+=======================
+Gera artigos evergreen estrategicos para o mercado americano.
+O banner OG e gerado automaticamente pelo Astro no build.
+
+Uso:
+  python scripts/content_engine.py --topic "how to build better habits" \\
+                                   --slug  "how-to-build-better-habits"  \\
+                                   --niche "productivity"
+
+Requisitos:
+  pip install groq          # para usar Groq API (recomendado)
+  # OU instale Ollama localmente: https://ollama.com  (gratis, offline)
+
+Variaveis de ambiente:
+  GROQ_API_KEY   — chave da Groq API (gratuita em console.groq.com)
+"""
+
+import argparse
+import re
+import json
+import os
+import sys
+from pathlib import Path
+
+# ─── Configuracao ────────────────────────────────────────────────────────────
+GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
+OUTPUT_DIR   = Path("src/content/posts")
+
+VALID_NICHES = [
+    "saas", "tools", "productivity", "finance",
+    "health", "marketing", "security", "software", "default"
+]
+
+# ─── Frases que envelhecem o conteudo ────────────────────────────────────────
+STALE_PATTERNS = [
+    (r"\bin \d{4}\b",                        ""),
+    (r"\brecently\b",                         ""),
+    (r"\blately\b",                           ""),
+    (r"\bnowadays\b",                         "commonly"),
+    (r"\bthe latest\b",                       "modern"),
+    (r"\bnew feature\b",                      "key feature"),
+    (r"\bin recent (years|months|weeks)\b",   ""),
+    (r"\bthis year\b",                        ""),
+    (r"\bas of \d{4}\b",                      ""),
+    (r"\bcurrently\b",                        "typically"),
+    (r"\btoday's\b",                          "modern"),
+    (r"\$[\d,]+(\.[\d]{2})?\b",              ""),   # remove precos USD
+    (r"\bR\$[\d,]+\b",                        ""),   # remove precos BRL
+    (r"\bper month\b",                        ""),
+    (r"\bper year\b",                         ""),
+    (r"/mo\b",                                ""),
+    (r"/yr\b",                                ""),
+]
+
+# ─── Mapa de links internos por nicho ────────────────────────────────────────
+# Atualize conforme for publicando novos posts
+INTERNAL_LINKS: dict[str, list[dict]] = {
+    "saas":         [{"text": "best project management tools",    "slug": "best-project-management-tools"}],
+    "tools":        [{"text": "essential tools for remote work",   "slug": "essential-tools-remote-work"}],
+    "productivity": [{"text": "how to manage your time better",    "slug": "how-to-manage-time-better"}],
+    "finance":      [{"text": "how to build an emergency fund",    "slug": "how-to-build-emergency-fund"}],
+    "health":       [{"text": "how to build sustainable habits",   "slug": "how-to-build-sustainable-habits"}],
+    "marketing":    [{"text": "how to grow your audience online",  "slug": "grow-audience-online"}],
+    "security":     [{"text": "how to protect your privacy online","slug": "protect-privacy-online"}],
+    "software":     [{"text": "best software for small business",  "slug": "best-software-small-business"}],
+    "default":      [],
+}
+
+# ─── Prompts ────────────────────────────────────────────────────────────────
+SYSTEM_PROMPT = """You are a senior content strategist writing for an American audience.
+
+RULES (NON-NEGOTIABLE):
+- Write in fluent, natural American English
+- NEVER mention specific years, dates, or prices
+- NEVER use: "in 2024", "in 2025", "in 2026", "recently", "lately", "this year", "as of", "new feature", "currently", "today"
+- Use timeless language: "modern", "commonly", "advanced", "key", "typically", "proven"
+- NEVER include price figures, subscription costs, or monetary comparisons
+- Tone: authoritative, helpful, direct — like NerdWallet, Wirecutter, or The Verge
+- Output ONLY valid Markdown. No HTML tags. No preamble. No explanation.
+
+STRUCTURE:
+1. H1: keyword-rich title (already provided as --topic, reuse it)
+2. Intro paragraph (100-150 words) — include main keyword in first 2 sentences
+3. Six H2 sections (see user prompt for exact titles)
+4. After H2 #3: insert the exact placeholder text [INTERNAL_LINK] on its own line
+5. After H2 #4: insert the exact placeholder text [AFFILIATE_CTA] on its own line
+6. FAQ section with 4 questions as H3 headings, each followed by a 2-3 sentence answer"""
+
+
+def build_user_prompt(topic: str, niche: str) -> str:
+    return f"""Write a complete evergreen article about: \"{topic}\"
+Niche: {niche}
+Target reader: American adult looking for practical, trustworthy advice
+Article intent: informational + soft affiliate conversion
+
+Required H2 sections (use these exact titles):
+1. What Is {topic.title()}
+2. Why It Matters
+3. How It Works
+4. How to Choose the Right Option
+5. Common Mistakes to Avoid
+6. Tips to Get the Most Out of It
+7. FAQ
+
+Placeholder rules:
+- Add [INTERNAL_LINK] on its own line at the END of section 3 (How It Works)
+- Add [AFFILIATE_CTA] on its own line at the END of section 4 (How to Choose)
+
+Output ONLY the article body in Markdown. Start directly with the H1."""
+
+
+# ─── Limpeza de conteudo datado ──────────────────────────────────────────────
+def clean_stale_content(text: str) -> str:
+    for pattern, replacement in STALE_PATTERNS:
+        text = re.sub(pattern, replacement, text, flags=re.IGNORECASE)
+    text = re.sub(r"  +", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+# ─── Injecao de links internos ───────────────────────────────────────────────
+def inject_internal_links(text: str, niche: str) -> str:
+    links = INTERNAL_LINKS.get(niche, [])
+    for link in links:
+        if "/posts/" + link["slug"] not in text:  # evita duplicar
+            anchor = f'[{link["text"]}](/posts/{link["slug"]})'
+            text = text.replace("[INTERNAL_LINK]", anchor, 1)
+    text = re.sub(r"\[INTERNAL_LINK\]", "", text)
+    return text
+
+
+# ─── Injecao do CTA de afiliado ──────────────────────────────────────────────
+def inject_affiliate_cta(text: str, niche: str) -> str:
+    cta = f"""
+> **Ready to get started?** Explore top-rated {niche} solutions trusted by professionals — compare features, read real reviews, and find the right fit for your needs. [See our top picks →](/posts/)
+"""
+    text = text.replace("[AFFILIATE_CTA]", cta, 1)
+    text = re.sub(r"\[AFFILIATE_CTA\]", "", text)  # limpa sobrando
+    return text
+
+
+# ─── Extrair meta description ────────────────────────────────────────────────
+def extract_description(body: str) -> str:
+    paragraphs = [
+        p.strip() for p in body.split("\n\n")
+        if p.strip() and not p.strip().startswith("#")
+        and not p.strip().startswith(">")
+    ]
+    first = re.sub(r"[*_`\[\]]", "", paragraphs[0]) if paragraphs else ""
+    first = re.sub(r"\(.*?\)", "", first).strip()
+    if len(first) > 155:
+        return first[:152].rsplit(" ", 1)[0] + "..."
+    return first
+
+
+# ─── Gerar schema JSON-LD para FAQ ──────────────────────────────────────────
+def generate_faq_schema(body: str, slug: str) -> str:
+    questions = re.findall(r"###?\s+(.+\?)", body)
+    if not questions:
+        return ""
+    items = [
+        {
+            "@type": "Question",
+            "name": q.strip(),
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": "See the full article for a detailed, practical answer."
+            }
+        }
+        for q in questions[:4]
+    ]
+    schema = {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": items
+    }
+    return f'\n\n<script type="application/ld+json">\n{json.dumps(schema, indent=2)}\n</script>'
+
+
+# ─── Montar frontmatter (compativel com src/content/config.ts) ───────────────
+def build_frontmatter(
+    topic: str,
+    slug: str,
+    niche: str,
+    description: str,
+) -> str:
+    return f"""---
+title: "{topic}"
+description: "{description}"
+category: "{niche}"
+cover: "/og/{slug}.png"
+ogImage: "/og/{slug}.png"
+featured: false
+draft: false
+---"""
+
+
+# ─── Geracao com Groq API ────────────────────────────────────────────────────
+def generate_with_groq(topic: str, niche: str) -> str:
+    if not GROQ_API_KEY:
+        print("⚠️  GROQ_API_KEY nao encontrada. Usando Ollama local...")
+        return generate_with_ollama(topic, niche)
+    try:
+        from groq import Groq
+        client = Groq(api_key=GROQ_API_KEY)
+        response = client.chat.completions.create(
+            model="llama-3.3-70b-versatile",
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user",   "content": build_user_prompt(topic, niche)},
+            ],
+            temperature=0.7,
+            max_tokens=4096,
+        )
+        return response.choices[0].message.content
+    except Exception as e:
+        print(f"⚠️  Groq falhou ({e}). Tentando Ollama...")
+        return generate_with_ollama(topic, niche)
+
+
+# ─── Geracao com Ollama local (fallback gratuito) ────────────────────────────
+def generate_with_ollama(topic: str, niche: str) -> str:
+    import subprocess
+    import json as j
+    payload = {
+        "model": "llama3",
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user",   "content": build_user_prompt(topic, niche)},
+        ],
+        "stream": False
+    }
+    try:
+        result = subprocess.run(
+            ["curl", "-s", "http://localhost:11434/api/chat", "-d", j.dumps(payload)],
+            capture_output=True, text=True, timeout=120
+        )
+        data = j.loads(result.stdout)
+        return data["message"]["content"]
+    except Exception as e:
+        print(f"❌ Ollama também falhou: {e}")
+        print("   Instale Ollama em https://ollama.com ou configure GROQ_API_KEY")
+        sys.exit(1)
+
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+def main():
+    parser = argparse.ArgumentParser(
+        description="InSpotGO Content Engine — gera artigos evergreen para o mercado americano"
+    )
+    parser.add_argument("--topic", required=True,
+                        help="Topico do artigo em ingles (ex: 'how to build better habits')")
+    parser.add_argument("--slug",  required=True,
+                        help="Slug da URL (ex: how-to-build-better-habits)")
+    parser.add_argument("--niche", default="default",
+                        choices=VALID_NICHES,
+                        help="Nicho: saas | tools | productivity | finance | health | marketing | security | software")
+    parser.add_argument("--llm",   default="groq",
+                        choices=["groq", "ollama"],
+                        help="LLM a usar (default: groq)")
+    args = parser.parse_args()
+
+    print(f"\n🚀 InSpotGO Content Engine")
+    print(f"   Topico : {args.topic}")
+    print(f"   Slug   : {args.slug}")
+    print(f"   Nicho  : {args.niche}")
+    print(f"   LLM    : {args.llm}\n")
+
+    # Verificar se o arquivo ja existe
+    output_file = OUTPUT_DIR / f"{args.slug}.md"
+    if output_file.exists():
+        confirm = input(f"⚠️  {output_file} ja existe. Sobrescrever? [s/N] ").strip().lower()
+        if confirm != "s":
+            print("   Cancelado.")
+            sys.exit(0)
+
+    # 1. Gerar conteudo via LLM
+    print("⏳ Gerando conteudo...")
+    raw = generate_with_groq(args.topic, args.niche) if args.llm == "groq" \
+          else generate_with_ollama(args.topic, args.niche)
+
+    # 2. Limpar conteudo datado
+    clean = clean_stale_content(raw)
+
+    # 3. Injetar links e CTAs
+    clean = inject_internal_links(clean, args.niche)
+    clean = inject_affiliate_cta(clean, args.niche)
+
+    # 4. Extrair description e gerar schema
+    description = extract_description(clean)
+    faq_schema  = generate_faq_schema(clean, args.slug)
+
+    # 5. Montar arquivo final
+    frontmatter = build_frontmatter(args.topic, args.slug, args.niche, description)
+    final       = f"{frontmatter}\n\n{clean}{faq_schema}\n"
+
+    # 6. Salvar
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(final, encoding="utf-8")
+
+    print(f"\n✅ Artigo salvo  : {output_file}")
+    print(f"🖼  Banner OG     : /og/{args.slug}.png  (gerado no astro build)")
+    print(f"📝 Description   : {description[:80]}...")
+    print(f"\n👉 Proximos passos:")
+    print(f"   1. Revise o artigo em {output_file}")
+    print(f"   2. git add . && git commit -m 'content: add {args.slug}'")
+    print(f"   3. git push  →  Cloudflare Pages faz o build + banner automaticamente\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pages/og/[slug].png.ts
+++ b/src/pages/og/[slug].png.ts
@@ -1,13 +1,12 @@
 // src/pages/og/[slug].png.ts
-// Banner engine — Satori + Resvg — zero API, gerado no build
+// Banner engine — Satori + Resvg
+// Fontes carregadas via fetch do Google Fonts CDN (funciona no Cloudflare Pages CI)
 import type { APIRoute, GetStaticPaths } from "astro";
 import { getCollection } from "astro:content";
 import satori from "satori";
 import { Resvg } from "@resvg/resvg-js";
-import fs from "node:fs";
-import path from "node:path";
 
-// ─── Paletas por nicho (evergreen, sem referência temporal) ────────────────
+// ─── Paletas por nicho ────────────────────────────────────────────────────
 const PALETTES: Record<string, { accent: string; glow: string; badge: string }> = {
   saas:         { accent: "#6366F1", glow: "#4F46E5", badge: "⚡ SaaS" },
   tools:        { accent: "#6366F1", glow: "#4F46E5", badge: "🛠 Tools" },
@@ -20,16 +19,33 @@ const PALETTES: Record<string, { accent: string; glow: string; badge: string }> 
   default:      { accent: "#6366F1", glow: "#4F46E5", badge: "✦ InSpotGO" },
 };
 
-// ─── Carga de fontes (Inter baixada em /public/fonts/) ────────────────────
-function loadFont(filename: string): Buffer {
-  const fontPath = path.resolve(process.cwd(), "public", "fonts", filename);
-  if (!fs.existsSync(fontPath)) {
-    throw new Error(`Font not found: ${fontPath} — download Inter from https://fonts.google.com/specimen/Inter`);
+// ─── URLs das fontes Inter (Google Fonts CDN — sem necessidade de arquivos locais) ──
+const FONT_URLS = {
+  black:   "https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuDyfAZ9hiJ-Ek-_EeA.woff",
+  regular: "https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfAZ9hiJ-Ek-_EeA.woff",
+};
+
+// Cache em memória para reutilizar entre renders no mesmo processo de build
+let _fontBlack: ArrayBuffer | null = null;
+let _fontRegular: ArrayBuffer | null = null;
+
+async function getFonts(): Promise<{ black: ArrayBuffer; regular: ArrayBuffer }> {
+  if (_fontBlack && _fontRegular) {
+    return { black: _fontBlack, regular: _fontRegular };
   }
-  return fs.readFileSync(fontPath);
+  const [blackRes, regularRes] = await Promise.all([
+    fetch(FONT_URLS.black),
+    fetch(FONT_URLS.regular),
+  ]);
+  if (!blackRes.ok || !regularRes.ok) {
+    throw new Error(`[OG] Failed to fetch fonts: black=${blackRes.status} regular=${regularRes.status}`);
+  }
+  _fontBlack   = await blackRes.arrayBuffer();
+  _fontRegular = await regularRes.arrayBuffer();
+  return { black: _fontBlack, regular: _fontRegular };
 }
 
-// ─── Static paths (1 banner por post) ────────────────────────────────────
+// ─── Static paths (1 banner por post) ─────────────────────────────────────
 export const getStaticPaths: GetStaticPaths = async () => {
   const posts = await getCollection("posts");
   return posts.map((post) => ({
@@ -42,7 +58,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
   }));
 };
 
-// ─── Endpoint GET ────────────────────────────────────────────────────────
+// ─── Endpoint GET ──────────────────────────────────────────────────────────
 export const GET: APIRoute = async ({ props }) => {
   const { title, description, category } = props as {
     title: string;
@@ -52,21 +68,17 @@ export const GET: APIRoute = async ({ props }) => {
 
   const palette = PALETTES[category] ?? PALETTES.default;
 
-  let fontBold: Buffer;
-  let fontRegular: Buffer;
+  let fonts: { black: ArrayBuffer; regular: ArrayBuffer };
   try {
-    fontBold    = loadFont("Inter-Black.ttf");
-    fontRegular = loadFont("Inter-Regular.ttf");
+    fonts = await getFonts();
   } catch (e) {
-    console.error("[OG] Font load error:", e);
-    return new Response("Font files missing. See /public/fonts/README.md", { status: 500 });
+    console.error("[OG] Font fetch error:", e);
+    return new Response("Font fetch failed", { status: 500 });
   }
 
-  // Trunca título e descrição para caber no layout
   const safeTitle = title.length > 72 ? title.slice(0, 69) + "..." : title;
   const safeDesc  = description.length > 120 ? description.slice(0, 117) + "..." : description;
 
-  // Template do banner em objeto JSX compatível com Satori
   const template = {
     type: "div",
     props: {
@@ -83,7 +95,6 @@ export const GET: APIRoute = async ({ props }) => {
         fontFamily: "Inter",
       },
       children: [
-        // Glow radial de fundo
         {
           type: "div",
           props: {
@@ -98,7 +109,6 @@ export const GET: APIRoute = async ({ props }) => {
             },
           },
         },
-        // Segundo glow menor (profundidade)
         {
           type: "div",
           props: {
@@ -113,7 +123,6 @@ export const GET: APIRoute = async ({ props }) => {
             },
           },
         },
-        // Barra vertical de acento (esquerda)
         {
           type: "div",
           props: {
@@ -127,7 +136,6 @@ export const GET: APIRoute = async ({ props }) => {
             },
           },
         },
-        // Badge de nicho (topo esquerdo)
         {
           type: "div",
           props: {
@@ -148,7 +156,6 @@ export const GET: APIRoute = async ({ props }) => {
             children: palette.badge,
           },
         },
-        // Logo / branding topo direito
         {
           type: "div",
           props: {
@@ -179,7 +186,6 @@ export const GET: APIRoute = async ({ props }) => {
             ],
           },
         },
-        // Título principal
         {
           type: "div",
           props: {
@@ -197,7 +203,6 @@ export const GET: APIRoute = async ({ props }) => {
             children: safeTitle,
           },
         },
-        // Separador colorido
         {
           type: "div",
           props: {
@@ -210,7 +215,6 @@ export const GET: APIRoute = async ({ props }) => {
             },
           },
         },
-        // Descrição / subtítulo
         {
           type: "div",
           props: {
@@ -235,8 +239,8 @@ export const GET: APIRoute = async ({ props }) => {
       width: 1200,
       height: 630,
       fonts: [
-        { name: "Inter", data: fontBold,    weight: 900, style: "normal" },
-        { name: "Inter", data: fontRegular, weight: 400, style: "normal" },
+        { name: "Inter", data: fonts.black,   weight: 900, style: "normal" },
+        { name: "Inter", data: fonts.regular, weight: 400, style: "normal" },
       ],
     });
 

--- a/src/pages/og/[slug].png.ts
+++ b/src/pages/og/[slug].png.ts
@@ -1,0 +1,256 @@
+// src/pages/og/[slug].png.ts
+// Banner engine — Satori + Resvg — zero API, gerado no build
+import type { APIRoute, GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import satori from "satori";
+import { Resvg } from "@resvg/resvg-js";
+import fs from "node:fs";
+import path from "node:path";
+
+// ─── Paletas por nicho (evergreen, sem referência temporal) ────────────────
+const PALETTES: Record<string, { accent: string; glow: string; badge: string }> = {
+  saas:         { accent: "#6366F1", glow: "#4F46E5", badge: "⚡ SaaS" },
+  tools:        { accent: "#6366F1", glow: "#4F46E5", badge: "🛠 Tools" },
+  productivity: { accent: "#3B82F6", glow: "#2563EB", badge: "🎯 Productivity" },
+  finance:      { accent: "#10B981", glow: "#059669", badge: "💰 Finance" },
+  health:       { accent: "#F59E0B", glow: "#D97706", badge: "🌿 Health" },
+  marketing:    { accent: "#EC4899", glow: "#DB2777", badge: "📣 Marketing" },
+  security:     { accent: "#8B5CF6", glow: "#7C3AED", badge: "🔒 Security" },
+  software:     { accent: "#06B6D4", glow: "#0891B2", badge: "💻 Software" },
+  default:      { accent: "#6366F1", glow: "#4F46E5", badge: "✦ InSpotGO" },
+};
+
+// ─── Carga de fontes (Inter baixada em /public/fonts/) ────────────────────
+function loadFont(filename: string): Buffer {
+  const fontPath = path.resolve(process.cwd(), "public", "fonts", filename);
+  if (!fs.existsSync(fontPath)) {
+    throw new Error(`Font not found: ${fontPath} — download Inter from https://fonts.google.com/specimen/Inter`);
+  }
+  return fs.readFileSync(fontPath);
+}
+
+// ─── Static paths (1 banner por post) ────────────────────────────────────
+export const getStaticPaths: GetStaticPaths = async () => {
+  const posts = await getCollection("posts");
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: {
+      title:       post.data.title,
+      description: post.data.description ?? "",
+      category:    (post.data.category ?? "default").toLowerCase(),
+    },
+  }));
+};
+
+// ─── Endpoint GET ────────────────────────────────────────────────────────
+export const GET: APIRoute = async ({ props }) => {
+  const { title, description, category } = props as {
+    title: string;
+    description: string;
+    category: string;
+  };
+
+  const palette = PALETTES[category] ?? PALETTES.default;
+
+  let fontBold: Buffer;
+  let fontRegular: Buffer;
+  try {
+    fontBold    = loadFont("Inter-Black.ttf");
+    fontRegular = loadFont("Inter-Regular.ttf");
+  } catch (e) {
+    console.error("[OG] Font load error:", e);
+    return new Response("Font files missing. See /public/fonts/README.md", { status: 500 });
+  }
+
+  // Trunca título e descrição para caber no layout
+  const safeTitle = title.length > 72 ? title.slice(0, 69) + "..." : title;
+  const safeDesc  = description.length > 120 ? description.slice(0, 117) + "..." : description;
+
+  // Template do banner em objeto JSX compatível com Satori
+  const template = {
+    type: "div",
+    props: {
+      style: {
+        width: "1200px",
+        height: "630px",
+        background: "#080C18",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-end",
+        padding: "72px 80px",
+        position: "relative",
+        overflow: "hidden",
+        fontFamily: "Inter",
+      },
+      children: [
+        // Glow radial de fundo
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              top: "-140px",
+              right: "-100px",
+              width: "680px",
+              height: "680px",
+              borderRadius: "9999px",
+              background: `radial-gradient(circle, ${palette.glow}50 0%, transparent 65%)`,
+            },
+          },
+        },
+        // Segundo glow menor (profundidade)
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              bottom: "-80px",
+              left: "200px",
+              width: "400px",
+              height: "400px",
+              borderRadius: "9999px",
+              background: `radial-gradient(circle, ${palette.accent}18 0%, transparent 70%)`,
+            },
+          },
+        },
+        // Barra vertical de acento (esquerda)
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              left: "0",
+              top: "0",
+              bottom: "0",
+              width: "5px",
+              background: `linear-gradient(to bottom, ${palette.accent}, ${palette.accent}00)`,
+            },
+          },
+        },
+        // Badge de nicho (topo esquerdo)
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              top: "52px",
+              left: "80px",
+              background: `${palette.accent}20`,
+              border: `1px solid ${palette.accent}55`,
+              borderRadius: "9999px",
+              padding: "8px 22px",
+              color: palette.accent,
+              fontSize: "22px",
+              fontWeight: 400,
+              display: "flex",
+              alignItems: "center",
+            },
+            children: palette.badge,
+          },
+        },
+        // Logo / branding topo direito
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              top: "52px",
+              right: "80px",
+              color: "#334155",
+              fontSize: "20px",
+              fontWeight: 400,
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            },
+            children: [
+              {
+                type: "div",
+                props: {
+                  style: {
+                    width: "8px",
+                    height: "8px",
+                    borderRadius: "9999px",
+                    background: palette.accent,
+                  },
+                },
+              },
+              "inspotgo.com",
+            ],
+          },
+        },
+        // Título principal
+        {
+          type: "div",
+          props: {
+            style: {
+              color: "#FFFFFF",
+              fontSize: "62px",
+              fontWeight: 900,
+              lineHeight: 1.1,
+              letterSpacing: "-1.5px",
+              maxWidth: "950px",
+              marginBottom: "20px",
+              display: "flex",
+              flexWrap: "wrap",
+            },
+            children: safeTitle,
+          },
+        },
+        // Separador colorido
+        {
+          type: "div",
+          props: {
+            style: {
+              width: "48px",
+              height: "3px",
+              background: palette.accent,
+              borderRadius: "9999px",
+              marginBottom: "18px",
+            },
+          },
+        },
+        // Descrição / subtítulo
+        {
+          type: "div",
+          props: {
+            style: {
+              color: "#94A3B8",
+              fontSize: "24px",
+              fontWeight: 400,
+              maxWidth: "820px",
+              lineHeight: 1.5,
+              display: "flex",
+              flexWrap: "wrap",
+            },
+            children: safeDesc,
+          },
+        },
+      ],
+    },
+  };
+
+  try {
+    const svg = await satori(template as Parameters<typeof satori>[0], {
+      width: 1200,
+      height: 630,
+      fonts: [
+        { name: "Inter", data: fontBold,    weight: 900, style: "normal" },
+        { name: "Inter", data: fontRegular, weight: 400, style: "normal" },
+      ],
+    });
+
+    const resvg = new Resvg(svg, { fitTo: { mode: "width", value: 1200 } });
+    const png   = resvg.render().asPng();
+
+    return new Response(png, {
+      headers: {
+        "Content-Type":  "image/png",
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
+    });
+  } catch (err) {
+    console.error("[OG] Satori render error:", err);
+    return new Response("Banner generation failed", { status: 500 });
+  }
+};


### PR DESCRIPTION
## O que esta PR adiciona

Pipeline completo para gerar **artigos evergreen** + **banners OG 1200×630** automaticamente no build.

---

### Arquivos incluídos

| Arquivo | Função |
|---|---|
| `src/pages/og/[slug].png.ts` | Endpoint Astro — gera banner PNG via Satori + Resvg |
| `scripts/content_engine.py` | Gerador de artigos via Groq API (LLaMA 3.3 70B) ou Ollama local |
| `public/fonts/README.md` | Documentação (fontes agora carregadas via CDN, não mais obrigatórias) |
| `CONTENT-ENGINE.md` | Guia completo de uso e instalação |

---

### ⚠️ Fix incluído

**Problema:** Build do Cloudflare Pages falhava ao tentar ler fontes Inter de `/public/fonts/` (arquivos locais não existem no CI).

**Solução:** Fontes carregadas via `fetch()` direto do Google Fonts CDN no build-time, com cache em memória entre os renders. Zero arquivos para gerenciar.

---

### Como usar após o merge

```bash
# 1. Instalar dependências Node (uma vez)
npm install satori @resvg/resvg-js

# 2. Adicionar chave Groq no .env
GROQ_API_KEY=gsk_xxxxxxxxxxxx

# 3. Gerar artigo
python scripts/content_engine.py \
  --topic "how to improve focus while working from home" \
  --slug  "improve-focus-working-from-home" \
  --niche "productivity"

# 4. Commitar e publicar — banner gerado automaticamente no deploy
git add . && git commit -m "content: add improve-focus-working-from-home" && git push
```

---

### Segurança
- ✅ Nenhum arquivo existente foi modificado
- ✅ Build continua passando normalmente
- ✅ Banners retornam HTTP 500 silencioso em caso de falha (não quebra o deploy)
- ✅ Script Python pergunta antes de sobrescrever posts existentes